### PR TITLE
[FIX] Explicitly Cast Port to String for Prod Env Variable

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -95,7 +95,7 @@ Rails.application.configure do
   # Skip DNS rebinding protection for the default health check endpoint.
   # config.host_authorization = { exclude: ->(request) { request.path == "/up" } }
   # --- BEGIN PROD DB CRED INITIALIZATION --- #
-  ENV['DB_PORT'] ||= Rails.application.credentials.config[:DB_PORT]
+  ENV['DB_PORT'] ||= String(Rails.application.credentials.config[:DB_PORT])
   ENV['DB_USER'] ||= Rails.application.credentials.config[:DB_USER]
   ENV['DB_PASSWORD'] ||= Rails.application.credentials.config[:DB_PASSWORD]
   ENV['DB_NAME'] ||= Rails.application.credentials.config[:DB_NAME]


### PR DESCRIPTION
# General Info

- Pivotal Tracker Story: N/A
- [ ] Breaking?

# Changes

- Cast prod port to string

# Testing

Successfully deploy this branch to heroku

# Documentation

N/A

# Checklist

- [ ] Name of branch corresponds to story
