### PR TITLE
Fixed weird interaction with Canvas due_at api response.

### DIFF
--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -110,7 +110,11 @@ class Course < ApplicationRecord
     end
 
     # Extract lock_at for late_due_date
-    assignment.late_due_date = DateTime.parse(assignment_data['lock_at']) if assignment_data['lock_at'].present?
+    if assignment_data['base_date'] && assignment_data['base_date']['lock_at'].present?
+      assignment.late_due_date = DateTime.parse(assignment_data['base_date']['lock_at'])
+    elsif assignment_data['lock_at'].present?
+      assignment.late_due_date = DateTime.parse(assignment_data['lock_at'])
+    end
 
     assignment.save!
   end

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -101,8 +101,17 @@ class Course < ApplicationRecord
   def self.sync_assignment(course_to_lms, assignment_data)
     assignment = Assignment.find_or_initialize_by(course_to_lms_id: course_to_lms.id, external_assignment_id: assignment_data['id'])
     assignment.name = assignment_data['name']
-    assignment.due_date = DateTime.parse(assignment_data['due_at']) if assignment_data['due_at'].present?
+
+    # Extract due_at from base_date if present
+    if assignment_data['base_date'] && assignment_data['base_date']['due_at'].present?
+      assignment.due_date = DateTime.parse(assignment_data['base_date']['due_at'])
+    elsif assignment_data['due_at'].present?
+      assignment.due_date = DateTime.parse(assignment_data['due_at'])
+    end
+
+    # Extract lock_at for late_due_date
     assignment.late_due_date = DateTime.parse(assignment_data['lock_at']) if assignment_data['lock_at'].present?
+
     assignment.save!
   end
 

--- a/app/models/course_to_lms.rb
+++ b/app/models/course_to_lms.rb
@@ -12,16 +12,21 @@ class CourseToLms < ApplicationRecord
       req.params['include[]'] = 'all_dates' # Include all dates in the response
     end
 
-    
     if response.success?
       assignments = JSON.parse(response.body)
-      Rails.logger.info "Assignments fetched successfully: #{assignments}"
 
       # Process assignments to extract base dates
       assignments.each do |assignment|
         if assignment['all_dates']
           base_date = assignment['all_dates'].find { |date| date['base'] == true }
-          assignment['base_date'] = base_date if base_date
+          if base_date
+            assignment['base_date'] = base_date
+            Rails.logger.info "Base date found for assignment #{assignment['id']}: #{base_date}"
+          else
+            Rails.logger.warn "No base date found for assignment #{assignment['id']}"
+          end
+        else
+          Rails.logger.warn "No 'all_dates' field for assignment #{assignment['id']}"
         end
       end
 

--- a/app/models/course_to_lms.rb
+++ b/app/models/course_to_lms.rb
@@ -19,14 +19,7 @@ class CourseToLms < ApplicationRecord
       assignments.each do |assignment|
         if assignment['all_dates']
           base_date = assignment['all_dates'].find { |date| date['base'] == true }
-          if base_date
-            assignment['base_date'] = base_date
-            Rails.logger.info "Base date found for assignment #{assignment['id']}: #{base_date}"
-          else
-            Rails.logger.warn "No base date found for assignment #{assignment['id']}"
-          end
-        else
-          Rails.logger.warn "No 'all_dates' field for assignment #{assignment['id']}"
+          assignment['base_date'] = base_date
         end
       end
 

--- a/spec/models/course_to_lms_spec.rb
+++ b/spec/models/course_to_lms_spec.rb
@@ -38,6 +38,13 @@ RSpec.describe CourseToLms, type: :model do
     context 'when the API call fails' do
       before do
         stub_request(:get, "#{ENV.fetch('CANVAS_URL')}/api/v1/courses/123/assignments")
+          .with(
+            headers: {
+              'Authorization' => "Bearer #{token}",
+              'Content-Type' => 'application/json'
+            },
+            query: { 'include[]' => 'all_dates' }
+          )
           .to_return(status: 500, body: 'Internal Server Error')
       end
 

--- a/spec/models/course_to_lms_spec.rb
+++ b/spec/models/course_to_lms_spec.rb
@@ -22,7 +22,8 @@ RSpec.describe CourseToLms, type: :model do
           headers: {
             'Authorization' => "Bearer #{token}",
             'Content-Type' => 'application/json'
-          }
+          },
+          query: { 'include[]' => 'all_dates' }
         )
         .to_return(status: 200, body: assignments_response.to_json, headers: { 'Content-Type' => 'application/json' })
     end


### PR DESCRIPTION
# General Info
Fixed our application to use the correct due_at. Canvas's assignment api response includes the due_at date for the most lenient override/extension for a student. Fixed it so that our application always uses the base due_at.
