### PR TITLE
Allow students to Cancel request without deleting the request

### DIFF
--- a/app/controllers/requests_controller.rb
+++ b/app/controllers/requests_controller.rb
@@ -79,11 +79,15 @@ class RequestsController < ApplicationController
     end
   end
 
-  def destroy
+  def cancel
     @request = @course.requests.find_by(id: params[:id])
     return redirect_to course_path(@course), alert: 'Request not found.' unless @request
 
-    @request.destroy
+    if @request.reject(@user)
+      redirect_to course_requests_path(@course), notice: 'Request denied successfully.'
+    else
+      redirect_to course_requests_path(@course), alert: 'Failed to deny the request.'
+    end
     redirect_to course_path(@course), notice: 'Request was successfully deleted.'
   end
 

--- a/app/controllers/requests_controller.rb
+++ b/app/controllers/requests_controller.rb
@@ -83,13 +83,11 @@ class RequestsController < ApplicationController
     @request = @course.requests.find_by(id: params[:id])
     return redirect_to course_path(@course), alert: 'Request not found.' unless @request
 
-    Rails.logger.info "Cancelling request: #{@request.inspect}"
     if @request.reject(@user)
       redirect_to course_requests_path(@course), notice: 'Request cancelled successfully.'
     else
       redirect_to course_requests_path(@course), alert: 'Failed to cancelled the request.'
     end
-    
   end
 
   def approve

--- a/app/controllers/requests_controller.rb
+++ b/app/controllers/requests_controller.rb
@@ -84,9 +84,9 @@ class RequestsController < ApplicationController
     return redirect_to course_path(@course), alert: 'Request not found.' unless @request
 
     if @request.reject(@user)
-      redirect_to course_requests_path(@course), notice: 'Request cancelled successfully.'
+      redirect_to course_requests_path(@course), notice: 'Request canceled successfully.'
     else
-      redirect_to course_requests_path(@course), alert: 'Failed to cancelled the request.'
+      redirect_to course_requests_path(@course), alert: 'Failed to canceled the request.'
     end
   end
 

--- a/app/controllers/requests_controller.rb
+++ b/app/controllers/requests_controller.rb
@@ -86,7 +86,7 @@ class RequestsController < ApplicationController
     if @request.reject(@user)
       redirect_to course_requests_path(@course), notice: 'Request canceled successfully.'
     else
-      redirect_to course_requests_path(@course), alert: 'Failed to canceled the request.'
+      redirect_to course_requests_path(@course), alert: 'Failed to cancel the request.'
     end
   end
 

--- a/app/controllers/requests_controller.rb
+++ b/app/controllers/requests_controller.rb
@@ -83,12 +83,13 @@ class RequestsController < ApplicationController
     @request = @course.requests.find_by(id: params[:id])
     return redirect_to course_path(@course), alert: 'Request not found.' unless @request
 
+    Rails.logger.info "Cancelling request: #{@request.inspect}"
     if @request.reject(@user)
-      redirect_to course_requests_path(@course), notice: 'Request denied successfully.'
+      redirect_to course_requests_path(@course), notice: 'Request cancelled successfully.'
     else
-      redirect_to course_requests_path(@course), alert: 'Failed to deny the request.'
+      redirect_to course_requests_path(@course), alert: 'Failed to cancelled the request.'
     end
-    redirect_to course_path(@course), notice: 'Request was successfully deleted.'
+    
   end
 
   def approve

--- a/app/views/requests/student_show.html.erb
+++ b/app/views/requests/student_show.html.erb
@@ -104,16 +104,16 @@
 				<div class="d-flex justify-content-center mt-4">
 				  <% if @request.status == 'pending' %>
 					<%= link_to 'Edit Request', edit_course_request_path(@course, @request), class: "btn btn-secondary me-3" %>
-					<%= button_to "Delete Request",
+					<%= button_to "Cancel Request",
 						course_request_path(@course, @request),
-						method: :delete,
+						method: :cancel,
 						class: "btn btn-danger me-3",
 						data: {
-							confirm: "Are you sure you want to delete this request?",
-							confirm_title: "Confirm Deletion",
-							confirm_body: "This request will be permanently removed and cannot be recovered.",
+							confirm: "Are you sure you want to cancel this request?",
+							confirm_title: "Confirm Cancellation",
+							confirm_body: "This request will be canceled and cannot be recovered.",
 							confirm_ok: "Yes, delete it",
-							confirm_cancel: "Cancel",
+							confirm_cancel: "No, keep it",
 							confirm_ok_class: "btn btn-danger",
 							confirm_cancel_class: "btn btn-secondary"
 						} %>

--- a/app/views/requests/student_show.html.erb
+++ b/app/views/requests/student_show.html.erb
@@ -105,8 +105,8 @@
 				  <% if @request.status == 'pending' %>
 					<%= link_to 'Edit Request', edit_course_request_path(@course, @request), class: "btn btn-secondary me-3" %>
 					<%= button_to "Cancel Request",
-						course_request_path(@course, @request),
-						method: :cancel,
+						cancel_course_request_path(@course, @request),
+						method: :post,
 						class: "btn btn-danger me-3",
 						data: {
 							confirm: "Are you sure you want to cancel this request?",

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -40,6 +40,7 @@ Rails.application.routes.draw do
       member do
         post :approve
         post :reject
+        post :cancel
       end
     end
     resource :form_setting, only: [:edit, :update]

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2025_04_18_015921) do
+ActiveRecord::Schema[7.1].define(version: 2025_04_19_081719) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -32,6 +32,8 @@ ActiveRecord::Schema[7.1].define(version: 2025_04_18_015921) do
 
   create_table "course_settings", force: :cascade do |t|
     t.bigint "course_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.boolean "enable_extensions", default: false
     t.integer "auto_approve_days", default: 0
     t.integer "auto_approve_dsp_days", default: 0
@@ -40,8 +42,6 @@ ActiveRecord::Schema[7.1].define(version: 2025_04_18_015921) do
     t.string "reply_email"
     t.string "email_subject", default: "Extension Request Status: {{status}} - {{course_code}}"
     t.text "email_template", default: "Dear {{student_name}},\n\nYour extension request for {{assignment_name}} in {{course_name}} ({{course_code}}) has been {{status}}.\n\nExtension Details:\n- Original Due Date: {{original_due_date}}\n- New Due Date: {{new_due_date}}\n- Extension Days: {{extension_days}}\n\nIf you have any questions, please contact the course staff.\n\nBest regards,\n{{course_name}} Staff"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
     t.index ["course_id"], name: "index_course_settings_on_course_id"
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2025_04_19_081719) do
+ActiveRecord::Schema[7.1].define(version: 2025_04_18_015921) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -32,8 +32,6 @@ ActiveRecord::Schema[7.1].define(version: 2025_04_19_081719) do
 
   create_table "course_settings", force: :cascade do |t|
     t.bigint "course_id", null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
     t.boolean "enable_extensions", default: false
     t.integer "auto_approve_days", default: 0
     t.integer "auto_approve_dsp_days", default: 0
@@ -42,6 +40,8 @@ ActiveRecord::Schema[7.1].define(version: 2025_04_19_081719) do
     t.string "reply_email"
     t.string "email_subject", default: "Extension Request Status: {{status}} - {{course_code}}"
     t.text "email_template", default: "Dear {{student_name}},\n\nYour extension request for {{assignment_name}} in {{course_name}} ({{course_code}}) has been {{status}}.\n\nExtension Details:\n- Original Due Date: {{original_due_date}}\n- New Due Date: {{new_due_date}}\n- Extension Days: {{extension_days}}\n\nIf you have any questions, please contact the course staff.\n\nBest regards,\n{{course_name}} Staff"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.index ["course_id"], name: "index_course_settings_on_course_id"
   end
 

--- a/spec/controllers/requests_controller_spec.rb
+++ b/spec/controllers/requests_controller_spec.rb
@@ -164,7 +164,7 @@ RSpec.describe RequestsController, type: :controller do
       post :cancel, params: { course_id: course.id, id: request.id }
 
       expect(response).to redirect_to(course_requests_path(course))
-      expect(flash[:alert]).to match(/Failed to cancel the request./i)
+      expect(flash[:alert]).to match('Failed to cancel the request.')
       expect(request.reload.status).not_to eq('denied')
     end
   end

--- a/spec/controllers/requests_controller_spec.rb
+++ b/spec/controllers/requests_controller_spec.rb
@@ -137,11 +137,35 @@ RSpec.describe RequestsController, type: :controller do
     end
   end
 
-  describe 'DELETE #destroy' do
-    it 'deletes the request' do
-      delete :destroy, params: { course_id: course.id, id: request.id }
+  describe 'POST #cancel' do
+    before do
+      session[:user_id] = user.canvas_uid
+      UserToCourse.create!(user: user, course: course, role: 'student')
+    end
+
+    it 'cancels the request and updates its status to denied' do
+      post :cancel, params: { course_id: course.id, id: request.id }
+
+      expect(response).to redirect_to(course_requests_path(course))
+      expect(flash[:notice]).to match(/Request canceled successfully./i)
+      expect(request.reload.status).to eq('denied')
+    end
+
+    it 'redirects if the request is not found' do
+      post :cancel, params: { course_id: course.id, id: '9999' }
+
       expect(response).to redirect_to(course_path(course))
-      expect(flash[:notice]).to match(/deleted/)
+      expect(flash[:alert]).to eq('Request not found.')
+    end
+
+    it 'does not cancel a request if it fails to update' do
+      allow_any_instance_of(Request).to receive(:reject).and_return(false)
+
+      post :cancel, params: { course_id: course.id, id: request.id }
+
+      expect(response).to redirect_to(course_requests_path(course))
+      expect(flash[:alert]).to match(/Failed to cancel the request./i)
+      expect(request.reload.status).not_to eq('denied')
     end
   end
 


### PR DESCRIPTION
# General Info
Removed student ability to delete requests. Requests are now canceled (denied) and stored in history.