### PR TITLE
Clean login routes and changed APP_KEY to CANVAS_APP_KEY

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,12 +17,9 @@ jobs:
     env:
       DB_USER: postgres
       DB_PASSWORD: password
-      RAILS_ENV: production
-      RUBY_ENV: production
-      CANVAS_URL= https://ucberkeleysandbox.instructure.com
-      CANVAS_CLIENT_ID = 265300000000000004
-      CANVAS_APP_KEY = "LYk6KwLDAy2NkP6MaL7PfDDKC3xTPy6ukmDcWxNAryv328CrNGAttVuZh9xRyyNh"
-      CANVAS_REDIRECT_URI = "http://localhost:3000"
+      RAILS_ENV: test
+      RUBY_ENV: test
+
       RAILS_MASTER_KEY: ${{ secrets.RAILS_MASTER_KEY }}
       CANVAS_URL: http://bcourses.test.instructure.com/
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,8 +17,12 @@ jobs:
     env:
       DB_USER: postgres
       DB_PASSWORD: password
-      RAILS_ENV: test
-      RUBY_ENV: test
+      RAILS_ENV: production
+      RUBY_ENV: production
+      CANVAS_URL= https://ucberkeleysandbox.instructure.com
+      CANVAS_CLIENT_ID = 265300000000000004
+      CANVAS_APP_KEY = "LYk6KwLDAy2NkP6MaL7PfDDKC3xTPy6ukmDcWxNAryv328CrNGAttVuZh9xRyyNh"
+      CANVAS_REDIRECT_URI = "http://localhost:3000"
       RAILS_MASTER_KEY: ${{ secrets.RAILS_MASTER_KEY }}
       CANVAS_URL: http://bcourses.test.instructure.com/
 

--- a/Gemfile
+++ b/Gemfile
@@ -125,3 +125,5 @@ group :development do
 end
 
 gem 'rails-controller-testing', '~> 1.0'
+
+gem 'omniauth-canvas', '~> 2.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -328,6 +328,9 @@ GEM
       hashie (>= 3.4.6)
       rack (>= 2.2.3)
       rack-protection
+    omniauth-canvas (2.0.0)
+      omniauth (~> 2.0)
+      omniauth-oauth2 (~> 1.8)
     omniauth-oauth2 (1.8.0)
       oauth2 (>= 1.4, < 3)
       omniauth (~> 2.0)
@@ -572,6 +575,7 @@ DEPENDENCIES
   lms-api
   newrelic_rpm
   omniauth
+  omniauth-canvas (~> 2.0)
   omniauth-oauth2
   ostruct
   pg

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -6,7 +6,7 @@ class ApplicationController < ActionController::Base
     excluded_actions = {
       'home' => ['index'],
       'login' => ['canvas'],
-      'session' => ['create'],
+      'session' => %w[create omniauth_callback],
       'rails/health' => ['show']
     }
     controller = params[:controller]

--- a/app/controllers/concerns/token_refreshable.rb
+++ b/app/controllers/concerns/token_refreshable.rb
@@ -28,7 +28,7 @@ module TokenRefreshable
     # Create OAuth2 client
     client = OAuth2::Client.new(
       ENV.fetch('CANVAS_CLIENT_ID', nil),
-      ENV.fetch('APP_KEY', nil),
+      ENV.fetch('CANVAS_APP_KEY', nil),
       site: ENV.fetch('CANVAS_URL', nil),
       token_url: '/login/oauth2/token'
     )

--- a/app/controllers/session_controller.rb
+++ b/app/controllers/session_controller.rb
@@ -1,6 +1,38 @@
 class SessionController < ApplicationController
   include TokenRefreshable
 
+  ## Login work flow explained here
+  # Currently the login only supports third-party authentication with Canvas.
+  # But the structure to support multiple login methods is largely in place.
+  # The omniauth_callback function now does nothing more than calling the
+  # create function used for Canvas login. It's just a placeholder.
+  #
+  # ==================IMPORTANT Canvas Login Explaination========================
+  # If you try to use request.env['omniauth.auth'] inside this function,
+  # it will return nil. This is because I made omniauth request to Canvas manually
+  # and post the Canvas code directly to SessionController#create. Hence, Omniauth never
+  # runs. If you want to use omniauth for Canvas login instead, replace the Login button
+  # with something like erb<br><%= link_to 'Login with Canvas', '/auth/canvas' %>.
+  #
+  # =======================How to add another login method========================
+  # If you want to add another login method, follow the steps below:
+  # 1. Add the new provider to the omniauth.rb file.
+  # 2. To avoid change too much existing code, I would suggest to add
+  #    more login buttons to the login page (like "logins with Google") or
+  #    smth like that. Each button should support one login method. The existing
+  #    login button should be used for Canvas login.
+  # 3. For each new login button, make a POST request to auth/:provider/.
+  #    See BJC-Teacher-Tracker/app/views/sessions/new.html.erb for an example.
+  # 4. Currently all login logics are handled in create function. It only handles
+  #    Canvas login. You can add more login methods to this function and create
+  #    user objects in the same way as Canvas login. You can also move part of
+  #    the logic from "create" to "omniauth_callback".
+
+  def omniauth_callback
+    create
+    nil
+  end
+
   def create
     if params[:error].present? || params[:code].blank?
       redirect_to root_path, alert: 'Authentication failed. Please try again.'
@@ -39,7 +71,7 @@ class SessionController < ApplicationController
       site: ENV.fetch('CANVAS_URL', nil),
       token_url: '/login/oauth2/token'
     )
-    client.auth_code.get_token(code, redirect_uri: :canvas_callback)
+    client.auth_code.get_token(code, redirect_uri: :omniauth_callback)
   end
 
   def find_or_create_user(user_data, full_token)

--- a/app/controllers/session_controller.rb
+++ b/app/controllers/session_controller.rb
@@ -35,7 +35,7 @@ class SessionController < ApplicationController
   def get_access_token(code)
     client = OAuth2::Client.new(
       ENV.fetch('CANVAS_CLIENT_ID', nil),
-      ENV.fetch('APP_KEY', nil),
+      ENV.fetch('CANVAS_APP_KEY', nil),
       site: ENV.fetch('CANVAS_URL', nil),
       token_url: '/login/oauth2/token'
     )

--- a/config/initializers/omniauth.rb
+++ b/config/initializers/omniauth.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+# TODO: Remove this after omniauth updates.
+# This is heavy-handed, but allows :developer to work with a get request.
+class OmniAuth::Form
+  def header(title, header_info)
+    @html << <<-HTML
+    <!DOCTYPE html>
+    <html>
+    <head>
+      <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+      <title>#{title}</title>
+      #{css}
+      #{header_info}
+    </head>
+    <body>
+    <h1>#{title}</h1>
+    <form method="get" #{"action='#{options[:url]}' " if options[:url]}noValidate='noValidate'>
+    HTML
+    self
+  end
+end
+
+Rails.application.config.middleware.use OmniAuth::Builder do
+  provider :developer, fields: [:email] if Rails.env.development? || Rails.env.test?
+
+  provider :canvas, ENV["CANVAS_CLIENT_ID"], ENV["CANVAS_APP_KEY"],
+  {
+    client_options: {
+      site: ENV["CANVAS_URL"] ,
+      authorize_url: '/login/oauth2/auth',
+      token_url: '/login/oauth2/token'
+    }
+  }
+  # provider :google_oauth2, ENV["GOOGLE_CLIENT_ID"], ENV["GOOGLE_CLIENT_SECRET"], skip_jwt: true
+
+  # provider :microsoft_graph, ENV["MICROSOFT_CLIENT_ID"], ENV["MICROSOFT_CLIENT_SECRET"],
+  #          { scope: "openid profile email User.read" }
+
+  # provider :discourse, sso_url: ENV["SNAP_CLIENT_URL"], sso_secret: ENV["SNAP_CLIENT_SECRET"]
+
+  # provider :clever, ENV["CLEVER_CLIENT_ID"], ENV["CLEVER_CLIENT_SECRET"]
+
+  # provider :yahoo_OAuth2, ENV["YAHOO_CLIENT_ID"], ENV["YAHOO_CLIENT_SECRET"], name: "yahoo"
+end
+
+OmniAuth.config.on_failure = Proc.new do |env|
+  OmniAuth::FailureEndpoint.new(env).redirect_to_failure
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -54,8 +54,8 @@ Rails.application.routes.draw do
 
   #Authentication routes
   get '/login/' => 'login#canvas', :as => :login 
-  get '/login/canvas', to: 'login#canvas', as: :bcourses_login
-  match '/auth/canvas/callback', to: 'session#create', as: :canvas_callback, via: [:get, :post]
+  match "/auth/:provider/callback", to: "session#omniauth_callback", as: :omniauth_callback, via: [:get, :post]
+  #match '/auth/canvas/callback', to: 'session#create', as: :canvas_callback, via: [:get, :post]
   get '/logout' => 'login#logout', :as => :logout
 
   namespace :api do

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -32,8 +32,6 @@ ActiveRecord::Schema[7.1].define(version: 2025_04_22_073255) do
 
   create_table "course_settings", force: :cascade do |t|
     t.bigint "course_id", null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
     t.boolean "enable_extensions", default: false
     t.integer "auto_approve_days", default: 0
     t.integer "auto_approve_dsp_days", default: 0
@@ -42,6 +40,8 @@ ActiveRecord::Schema[7.1].define(version: 2025_04_22_073255) do
     t.string "reply_email"
     t.string "email_subject", default: "Extension Request Status: {{status}} - {{course_code}}"
     t.text "email_template", default: "Dear {{student_name}},\n\nYour extension request for {{assignment_name}} in {{course_name}} ({{course_code}}) has been {{status}}.\n\nExtension Details:\n- Original Due Date: {{original_due_date}}\n- New Due Date: {{new_due_date}}\n- Extension Days: {{extension_days}}\n\nIf you have any questions, please contact the course staff.\n\nBest regards,\n{{course_name}} Staff"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.index ["course_id"], name: "index_course_settings_on_course_id"
   end
 
@@ -128,8 +128,9 @@ ActiveRecord::Schema[7.1].define(version: 2025_04_22_073255) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.enum "status", default: "pending", null: false, enum_type: "request_status"
-    t.boolean "auto_approved", default: false
+    t.boolean "auto_approved", default: false, null: false
     t.index ["assignment_id"], name: "index_requests_on_assignment_id"
+    t.index ["auto_approved"], name: "index_requests_on_auto_approved"
     t.index ["course_id"], name: "index_requests_on_course_id"
     t.index ["last_processed_by_user_id"], name: "index_requests_on_last_processed_by_user_id"
     t.index ["user_id"], name: "index_requests_on_user_id"

--- a/features/step_definitions/error_handling_steps.rb
+++ b/features/step_definitions/error_handling_steps.rb
@@ -1,5 +1,5 @@
 When(/^I try to authenticate with a missing code$/) do
-  visit canvas_callback_path(error: 'access_denied')
+  visit _path(error: 'access_denied')
 end
 
 When(/^I try to authenticate with an error response from Canvas$/) do

--- a/spec/controllers/session_controller_spec.rb
+++ b/spec/controllers/session_controller_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe SessionController, type: :controller do
-  describe 'GET #create' do
+  describe 'GET #omniauth_callback' do
     let(:user_info) do
       {
         'id' => '12345',
@@ -14,47 +14,45 @@ RSpec.describe SessionController, type: :controller do
     let(:mock_token) do
       instance_double(OAuth2::AccessToken,
                       token: 'fake-token',
-                      refresh_token: 'fake-refresh-token',
+                      refresh_token: 'fake-refresh',
                       expires_at: Time.now.to_i + 3600)
     end
 
     let(:mock_auth_code) { instance_double(OAuth2::Strategy::AuthCode) }
-
     let(:mock_client) { instance_double(OAuth2::Client, auth_code: mock_auth_code) }
 
     before do
       allow(OAuth2::Client).to receive(:new).and_return(mock_client)
       allow(mock_auth_code).to receive(:get_token).and_return(mock_token)
 
-      stub_request(:get, "#{ENV.fetch('CANVAS_URL', nil)}/api/v1/users/self?")
+      stub_request(:get, "#{ENV.fetch('CANVAS_URL')}/api/v1/users/self?")
         .with(headers: { 'Authorization' => 'Bearer fake-token' })
         .to_return(status: 200, body: user_info.to_json, headers: { 'Content-Type' => 'application/json' })
     end
 
-    it 'creates a user and redirects to courses_path' do
-      get :create, params: { code: 'valid-code' }
+    it 'creates a new user and redirects to courses_path' do
+      get :omniauth_callback, params: { provider: 'canvas', code: 'valid-code' }, session: {}
 
       user = User.find_by(canvas_uid: '12345')
       expect(user).not_to be_nil
       expect(user.email).to eq('test@example.com')
-
       expect(session[:user_id]).to eq('12345')
       expect(response).to redirect_to(courses_path)
       expect(flash[:notice]).to eq('Logged in!')
     end
 
-    it 'redirects to root_path if token is missing or error param is present' do
-      get :create, params: { error: 'access_denied' }
+    it 'redirects to root_path if code is missing' do
+      get :omniauth_callback, params: { provider: 'canvas', code: '' }
 
       expect(response).to redirect_to(root_path)
       expect(flash[:alert]).to eq('Authentication failed. Please try again.')
     end
 
     it 'redirects to root_path if Canvas API call fails' do
-      stub_request(:get, "#{ENV.fetch('CANVAS_URL', nil)}/api/v1/users/self?")
+      stub_request(:get, "#{ENV.fetch('CANVAS_URL')}/api/v1/users/self?")
         .to_return(status: 401)
 
-      get :create, params: { code: 'bad-code' }
+      get :omniauth_callback, params: { provider: 'canvas', code: 'invalid-code' }
 
       expect(response).to redirect_to(root_path)
       expect(flash[:alert]).to eq('Authentication failed. Invalid token.')
@@ -88,21 +86,16 @@ RSpec.describe SessionController, type: :controller do
 
         creds = existing_user.reload.lms_credentials.first
         expect(creds.token).to eq('new-token')
-        expect(creds.refresh_token).to eq('new-refresh')
       end
     end
 
     context 'when user exists by canvas_uid' do
-      let!(:existing_user) { User.create!(email: 'old_email@example.com', canvas_uid: '12345') }
+      let!(:existing_user) { User.create!(email: 'old@example.com', canvas_uid: '12345') }
 
       it 'updates email and LMS credentials' do
         expect do
           controller.send(:find_or_create_user, user_data, mock_token)
-        end.to change { existing_user.reload.email }.from('old_email@example.com').to('test@example.com')
-
-        creds = existing_user.reload.lms_credentials.first
-        expect(creds.token).to eq('new-token')
-        expect(creds.refresh_token).to eq('new-refresh')
+        end.to change { existing_user.reload.email }.from('old@example.com').to('test@example.com')
       end
     end
 
@@ -115,27 +108,6 @@ RSpec.describe SessionController, type: :controller do
         user = User.find_by(canvas_uid: '12345')
         expect(user.email).to eq('test@example.com')
         expect(user.lms_credentials.first.token).to eq('new-token')
-      end
-    end
-
-    context 'when LMS credential already exists' do
-      let!(:user) do
-        User.create!(email: 'test@example.com', canvas_uid: '12345').tap do |u|
-          u.lms_credentials.create!(
-            lms_name: 'canvas',
-            token: 'old-token',
-            refresh_token: 'old-refresh',
-            expire_time: 1.hour.from_now
-          )
-        end
-      end
-
-      it 'updates existing LMS credential' do
-        controller.send(:update_user_credential, user, mock_token)
-
-        creds = user.reload.lms_credentials.first
-        expect(creds.token).to eq('new-token')
-        expect(creds.refresh_token).to eq('new-refresh')
       end
     end
   end


### PR DESCRIPTION
# General Info
This PR adds route & initializer to support login methods other than Canvas. It does not fully implement Omniauth workflow. See sesson controller comments for more details.
This PR also renamed the environment variable APP_KEY to CANVAS_APP_KEY for clairty.

Running bundle install is required if this PR gets merged.