### PR TITLE
Delete course functionality added in Course Settings

### DIFF
--- a/app/assets/stylesheets/_custom_bootstrap.scss
+++ b/app/assets/stylesheets/_custom_bootstrap.scss
@@ -42,6 +42,13 @@ code {
       color: #ccdeff;
     }
   }
+
+  a.btn {
+    color: #fff;
+    &:hover {
+      color: #fff;
+    }
+  }
   
   .sidebar-container .nav-link:not(.active) {
     color: #f3f8fe !important;

--- a/app/assets/stylesheets/_custom_bootstrap.scss
+++ b/app/assets/stylesheets/_custom_bootstrap.scss
@@ -42,13 +42,6 @@ code {
       color: #ccdeff;
     }
   }
-
-  a.btn {
-    color: #fff;
-    &:hover {
-      color: #fff;
-    }
-  }
   
   .sidebar-container .nav-link:not(.active) {
     color: #f3f8fe !important;
@@ -360,6 +353,20 @@ code {
     }
   }
 }
+
+// disabled hover on disabled danger-outline-btn
+a.btn-outline-danger.disable:hover {
+  background-color: transparent !important;
+  color: #dc3545 !important;
+  border-color: #dc3545 !important;
+  pointer-events: none; /* optional: makes it unclickable */
+}
+
+/*
+*****************
+* Sidebar
+*****************
+*/
 
 #sidebar {
 	position: sticky;

--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -81,27 +81,15 @@ class CoursesController < ApplicationController
     @enrollments = @course.user_to_courses.includes(:user)
   end
 
-  # DELETES ALL COURSES, ASSIGNMENTS, EXTENSIONS, AND USER-TO-COURSE MAPPINGS
-  # This method is intended for use in development or testing environments only.
   def delete
-    # user_courses = Course.joins(:user_to_courses).where(user_to_courses: { user_id: @user.id })
-
-    # Find all assignments associated with the user's courses
     assignments = Assignment.where(course_to_lms_id: CourseToLms.where(course_id: @course.id).select(:id))
-
-    # Delete all extensions associated with those assignments
     Extension.where(assignment_id: assignments.select(:id)).destroy_all
-
-    # Delete the assignments, course-to-LMS mappings, and user-to-course mappings
     assignments.destroy_all
     CourseToLms.where(course_id: @course.id).destroy_all
     UserToCourse.where(course_id: @course.id).destroy_all
-
-    # Delete course_settings and form_settings associated with the user's courses
+    Request.where(course_id: @course.id).destroy_all
     CourseSettings.where(course_id: @course.id).destroy_all
     FormSetting.where(course_id: @course.id).destroy_all
-
-    # Delete courses that no longer have any user-to-course associations
     Course.where.missing(:user_to_courses).destroy_all
 
     redirect_to courses_path, notice: 'Course deleted successfully.'

--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -1,6 +1,6 @@
 class CoursesController < ApplicationController
   before_action :authenticate_user
-  before_action :set_course, only: %i[show edit sync_assignments sync_enrollments enrollments]
+  before_action :set_course, only: %i[show edit sync_assignments sync_enrollments enrollments delete]
   before_action :set_pending_request_count
   before_action :determine_user_role
 
@@ -83,28 +83,28 @@ class CoursesController < ApplicationController
 
   # DELETES ALL COURSES, ASSIGNMENTS, EXTENSIONS, AND USER-TO-COURSE MAPPINGS
   # This method is intended for use in development or testing environments only.
-  def delete_all
-    user_courses = Course.joins(:user_to_courses).where(user_to_courses: { user_id: @user.id })
+  def delete
+    # user_courses = Course.joins(:user_to_courses).where(user_to_courses: { user_id: @user.id })
 
     # Find all assignments associated with the user's courses
-    assignments = Assignment.where(course_to_lms_id: CourseToLms.where(course_id: user_courses).select(:id))
+    assignments = Assignment.where(course_to_lms_id: CourseToLms.where(course_id: @course.id).select(:id))
 
     # Delete all extensions associated with those assignments
     Extension.where(assignment_id: assignments.select(:id)).destroy_all
 
     # Delete the assignments, course-to-LMS mappings, and user-to-course mappings
     assignments.destroy_all
-    CourseToLms.where(course_id: user_courses).destroy_all
-    UserToCourse.where(course_id: user_courses).destroy_all
+    CourseToLms.where(course_id: @course.id).destroy_all
+    UserToCourse.where(course_id: @course.id).destroy_all
 
     # Delete course_settings and form_settings associated with the user's courses
-    CourseSettings.where(course_id: user_courses).destroy_all
-    FormSetting.where(course_id: user_courses).destroy_all
+    CourseSettings.where(course_id: @course.id).destroy_all
+    FormSetting.where(course_id: @course.id).destroy_all
 
     # Delete courses that no longer have any user-to-course associations
     Course.where.missing(:user_to_courses).destroy_all
 
-    redirect_to courses_path, notice: 'All your courses and associations have been deleted successfully.'
+    redirect_to courses_path, notice: 'Course deleted successfully.'
   end
 
   private

--- a/app/views/courses/edit.html.erb
+++ b/app/views/courses/edit.html.erb
@@ -125,7 +125,7 @@
                                 <div class="mb-3">
                                     <div class="text-start">
                                         <% if @course.course_settings&.enable_extensions %>
-                                            <%= link_to 'Delete Course (must have student extension requests disabled)', '#', class: 'btn btn-outline-danger disabled me-3', aria_disabled: 'true' %>
+                                            <%= link_to 'Delete Course (must have student extension requests disabled)', '#', class: 'btn btn-outline-danger disable me-3', aria_disabled: 'true' %>
                                         <% else %>
                                             <%= link_to 'Delete Course',
                                                         delete_course_path,

--- a/app/views/courses/edit.html.erb
+++ b/app/views/courses/edit.html.erb
@@ -125,12 +125,13 @@
                                 <div class="mb-3">
                                     <div class="text-start">
                                         <% if @course.course_settings&.enable_extensions %>
-                                            <%= link_to 'Delete Course (must have extensions disabled)', '#', class: 'btn btn-danger disabled', aria_disabled: 'true' %>
+                                            <%= link_to 'Delete Course (must have student extension requests disabled)', '#', class: 'btn btn-danger disabled', aria_disabled: 'true' %>
                                         <% else %>
-                                            <%= link_to 'Delete Course (must have extensions disabled)',
+                                            <%= link_to 'Delete Course (must have student extension requests disabled)',
                                                         delete_course_path,
                                                         method: :delete,
                                                         class: 'btn btn-danger',
+                                                        style: 'background-color: #c82333; color: #fff; border-color: #bd2130;',
                                                         data: {
                                                         confirm: 'Are you sure you want to delete this course? This action cannot be undone.'
                                                         } %>

--- a/app/views/courses/edit.html.erb
+++ b/app/views/courses/edit.html.erb
@@ -121,6 +121,19 @@
                                                           disabled: !@course.course_settings&.enable_emails %>
                                     </div>
                                 </div>
+
+                                <div class="mb-3">
+                                    <div class="text-start">
+                                        <%= button_to 'Delete Course (must have extensions disabled)',
+                                                    delete_course_path,
+                                                    method: :delete,
+                                                    class: 'btn btn-danger',
+                                                    disabled: @course.course_settings&.enable_extensions,
+                                                    data: {
+                                                        confirm: 'Are you sure you want to delete this course? This action cannot be undone.'
+                                                    } %>
+                                    </div>
+                                </div>
                             </div>
                         </div>
                     </div>

--- a/app/views/courses/edit.html.erb
+++ b/app/views/courses/edit.html.erb
@@ -125,13 +125,12 @@
                                 <div class="mb-3">
                                     <div class="text-start">
                                         <% if @course.course_settings&.enable_extensions %>
-                                            <%= link_to 'Delete Course (must have student extension requests disabled)', '#', class: 'btn btn-danger disabled', aria_disabled: 'true' %>
+                                            <%= link_to 'Delete Course (must have student extension requests disabled)', '#', class: 'btn btn-danger me-3 disabled', aria_disabled: 'true' %>
                                         <% else %>
                                             <%= link_to 'Delete Course (must have student extension requests disabled)',
                                                         delete_course_path,
                                                         method: :delete,
-                                                        class: 'btn btn-danger',
-                                                        style: 'background-color: #9b2f3b; color: #ffffff;',
+                                                        class: 'btn btn-danger me-3',
                                                         data: {
                                                         confirm: 'Are you sure you want to delete this course? This action cannot be undone.'
                                                         } %>

--- a/app/views/courses/edit.html.erb
+++ b/app/views/courses/edit.html.erb
@@ -125,7 +125,7 @@
                                 <div class="mb-3">
                                     <div class="text-start">
                                         <% if @course.course_settings&.enable_extensions %>
-                                            <%= link_to 'Delete Course (must have student extension requests disabled)', '#', class: 'btn btn-danger me-3 disabled', aria_disabled: 'true' %>
+                                            <%= link_to 'Delete Course (must have student extension requests disabled)', '#', class: 'btn btn-danger me-3 disabled text-white', aria_disabled: 'true' %>
                                         <% else %>
                                             <%= link_to 'Delete Course (must have student extension requests disabled)',
                                                         delete_course_path,

--- a/app/views/courses/edit.html.erb
+++ b/app/views/courses/edit.html.erb
@@ -131,7 +131,7 @@
                                                         delete_course_path,
                                                         method: :delete,
                                                         class: 'btn btn-danger',
-                                                        style: 'background-color: #c82333; color: #fff; border-color: #bd2130;',
+                                                        style: 'background-color: #9b2f3b; color: #ffffff;',
                                                         data: {
                                                         confirm: 'Are you sure you want to delete this course? This action cannot be undone.'
                                                         } %>

--- a/app/views/courses/edit.html.erb
+++ b/app/views/courses/edit.html.erb
@@ -196,6 +196,10 @@
                     <%= form.submit 'Save Settings', class: 'btn btn-success px-4' %>
                 </div>
             <% end %>
+
+            <div class="text-center">
+                <%= button_to 'Delete Course', delete_course_path, method: :delete, class: 'btn btn-danger', data: { confirm: 'Are you sure you want to delete all your courses and associations?' } %>
+            </div>
         </div>
     </div>
 </div>

--- a/app/views/courses/edit.html.erb
+++ b/app/views/courses/edit.html.erb
@@ -109,7 +109,7 @@
                                     </div>
                                 </div>
                                 
-                                <div class="mb-3 row border-bottom pb-3">
+                                <div class="mb-3 row">
                                     <label for="reply-email" class="col-sm-4 col-form-label">Course Reply Email Address</label>
                                     <div class="col-sm-8">
                                         <%= email_field_tag 'course_settings[reply_email]', 
@@ -121,21 +121,6 @@
                                                           disabled: !@course.course_settings&.enable_emails %>
                                     </div>
                                 </div>
-
-                                <div class="mb-3">
-                                    <div class="text-end">
-                                        <label class="form-label d-block mb-2">Delete course (must have extensions disabled)</label>
-                                        <%= button_to 'Delete Course',
-                                                    delete_course_path,
-                                                    method: :delete,
-                                                    class: 'btn btn-danger',
-                                                    disabled: @course.course_settings&.enable_extensions,
-                                                    data: {
-                                                        confirm: 'Are you sure you want to delete this course? This action cannot be undone.'
-                                                    } %>
-                                    </div>
-                                </div>
-
                             </div>
                         </div>
                     </div>
@@ -211,8 +196,6 @@
                     <%= form.submit 'Save Settings', class: 'btn btn-success px-4' %>
                 </div>
             <% end %>
-
-            
         </div>
     </div>
 </div>

--- a/app/views/courses/edit.html.erb
+++ b/app/views/courses/edit.html.erb
@@ -132,7 +132,7 @@
                                                         method: :delete,
                                                         class: 'btn btn-danger me-3',
                                                         data: {
-                                                        confirm: 'Are you sure you want to delete this course? This action cannot be undone.'
+                                                            confirm: 'Are you sure you want to delete this course? This action cannot be undone.'
                                                         } %>
                                         <% end %>
                                     </div>

--- a/app/views/courses/edit.html.erb
+++ b/app/views/courses/edit.html.erb
@@ -198,7 +198,7 @@
             <% end %>
 
             <div class="text-center">
-                <%= button_to 'Delete Course', delete_course_path, method: :delete, class: 'btn btn-danger', data: { confirm: 'Are you sure you want to delete all your courses and associations?' } %>
+                <%= button_to 'Delete Course', delete_courses_path, method: :delete, class: 'btn btn-danger', data: { confirm: 'Are you sure you want to delete all your courses and associations?' } %>
             </div>
         </div>
     </div>

--- a/app/views/courses/edit.html.erb
+++ b/app/views/courses/edit.html.erb
@@ -198,7 +198,7 @@
             <% end %>
 
             <div class="text-center">
-                <%= button_to 'Delete Course', delete_courses_path, method: :delete, class: 'btn btn-danger', data: { confirm: 'Are you sure you want to delete all your courses and associations?' } %>
+                <%= button_to 'Delete Course', delete_courses_path, method: :delete, class: 'btn btn-danger', data: { confirm: 'Are you sure you want to delete this course? This action cannot be undone.' } %>
             </div>
         </div>
     </div>

--- a/app/views/courses/edit.html.erb
+++ b/app/views/courses/edit.html.erb
@@ -125,9 +125,9 @@
                                 <div class="mb-3">
                                     <div class="text-start">
                                         <% if @course.course_settings&.enable_extensions %>
-                                            <%= link_to 'Delete Course (must have student extension requests disabled)', '#', class: 'btn btn-danger me-3 disabled text-white', aria_disabled: 'true' %>
+                                            <%= link_to 'Delete Course (must have student extension requests disabled)', '#', class: 'btn btn-outline-danger me-3', aria_disabled: 'true' %>
                                         <% else %>
-                                            <%= link_to 'Delete Course (must have student extension requests disabled)',
+                                            <%= link_to 'Delete Course',
                                                         delete_course_path,
                                                         method: :delete,
                                                         class: 'btn btn-danger me-3',

--- a/app/views/courses/edit.html.erb
+++ b/app/views/courses/edit.html.erb
@@ -198,7 +198,7 @@
             <% end %>
 
             <div class="text-center">
-                <%= button_to 'Delete Course', delete_courses_path, method: :delete, class: 'btn btn-danger', data: { confirm: 'Are you sure you want to delete this course? This action cannot be undone.' } %>
+                <%= button_to 'Delete Course', delete_course_path, method: :delete, class: 'btn btn-danger', data: { confirm: 'Are you sure you want to delete this course? This action cannot be undone.' } %>
             </div>
         </div>
     </div>

--- a/app/views/courses/edit.html.erb
+++ b/app/views/courses/edit.html.erb
@@ -122,11 +122,8 @@
                                     </div>
                                 </div>
 
-                                <div class="card-header bg-light">
-                                    <h2 class="card-title mb-0 h5">Delete Course</h2>
-                                </div>
                                 <div class="mb-3">
-                                    <div class="text-center">
+                                    <div class="text-end">
                                         <%= button_to 'Delete Course', delete_course_path, method: :delete, class: 'btn btn-danger', data: { confirm: 'Are you sure you want to delete this course? This action cannot be undone.' } %>
                                     </div>
                                 </div>

--- a/app/views/courses/edit.html.erb
+++ b/app/views/courses/edit.html.erb
@@ -125,7 +125,7 @@
                                 <div class="mb-3">
                                     <div class="text-start">
                                         <% if @course.course_settings&.enable_extensions %>
-                                            <%= link_to 'Delete Course (must have student extension requests disabled)', '#', class: 'btn btn-outline-danger me-3', aria_disabled: 'true' %>
+                                            <%= link_to 'Delete Course (must have student extension requests disabled)', '#', class: 'btn btn-outline-danger disabled me-3', aria_disabled: 'true' %>
                                         <% else %>
                                             <%= link_to 'Delete Course',
                                                         delete_course_path,

--- a/app/views/courses/edit.html.erb
+++ b/app/views/courses/edit.html.erb
@@ -109,7 +109,7 @@
                                     </div>
                                 </div>
                                 
-                                <div class="mb-3 row">
+                                <div class="mb-3 row border-bottom pb-3">
                                     <label for="reply-email" class="col-sm-4 col-form-label">Course Reply Email Address</label>
                                     <div class="col-sm-8">
                                         <%= email_field_tag 'course_settings[reply_email]', 
@@ -124,14 +124,17 @@
 
                                 <div class="mb-3">
                                     <div class="text-start">
-                                        <%= button_to 'Delete Course (must have extensions disabled)',
-                                                    delete_course_path,
-                                                    method: :delete,
-                                                    class: 'btn btn-danger',
-                                                    disabled: @course.course_settings&.enable_extensions,
-                                                    data: {
+                                        <% if @course.course_settings&.enable_extensions %>
+                                            <%= link_to 'Delete Course (must have extensions disabled)', '#', class: 'btn btn-danger disabled', aria_disabled: 'true' %>
+                                        <% else %>
+                                            <%= link_to 'Delete Course (must have extensions disabled)',
+                                                        delete_course_path,
+                                                        method: :delete,
+                                                        class: 'btn btn-danger',
+                                                        data: {
                                                         confirm: 'Are you sure you want to delete this course? This action cannot be undone.'
-                                                    } %>
+                                                        } %>
+                                        <% end %>
                                     </div>
                                 </div>
                             </div>

--- a/app/views/courses/edit.html.erb
+++ b/app/views/courses/edit.html.erb
@@ -109,7 +109,7 @@
                                     </div>
                                 </div>
                                 
-                                <div class="mb-3 row">
+                                <div class="mb-3 row border-bottom pb-3">
                                     <label for="reply-email" class="col-sm-4 col-form-label">Course Reply Email Address</label>
                                     <div class="col-sm-8">
                                         <%= email_field_tag 'course_settings[reply_email]', 
@@ -121,6 +121,16 @@
                                                           disabled: !@course.course_settings&.enable_emails %>
                                     </div>
                                 </div>
+
+                                <div class="card-header bg-light">
+                                    <h2 class="card-title mb-0 h5">Delete Course</h2>
+                                </div>
+                                <div class="mb-3">
+                                    <div class="text-center">
+                                        <%= button_to 'Delete Course', delete_course_path, method: :delete, class: 'btn btn-danger', data: { confirm: 'Are you sure you want to delete this course? This action cannot be undone.' } %>
+                                    </div>
+                                </div>
+
                             </div>
                         </div>
                     </div>
@@ -197,9 +207,7 @@
                 </div>
             <% end %>
 
-            <div class="text-center">
-                <%= button_to 'Delete Course', delete_course_path, method: :delete, class: 'btn btn-danger', data: { confirm: 'Are you sure you want to delete this course? This action cannot be undone.' } %>
-            </div>
+            
         </div>
     </div>
 </div>

--- a/app/views/courses/edit.html.erb
+++ b/app/views/courses/edit.html.erb
@@ -124,7 +124,15 @@
 
                                 <div class="mb-3">
                                     <div class="text-end">
-                                        <%= button_to 'Delete Course', delete_course_path, method: :delete, class: 'btn btn-danger', data: { confirm: 'Are you sure you want to delete this course? This action cannot be undone.' } %>
+                                        <label class="form-label d-block mb-2">Delete course (must have extensions disabled)</label>
+                                        <%= button_to 'Delete Course',
+                                                    delete_course_path,
+                                                    method: :delete,
+                                                    class: 'btn btn-danger',
+                                                    disabled: @course.course_settings&.enable_extensions,
+                                                    data: {
+                                                        confirm: 'Are you sure you want to delete this course? This action cannot be undone.'
+                                                    } %>
                                     </div>
                                 </div>
 

--- a/app/views/courses/index.html.erb
+++ b/app/views/courses/index.html.erb
@@ -39,7 +39,6 @@
             <div class="text-center my-3">
                 <a href="/courses/new" id="import-courses-button" class="btn btn-secondary ">Import courses from Canvas</a>
             </div>
-
         </div>
         <% end %>
 

--- a/app/views/courses/index.html.erb
+++ b/app/views/courses/index.html.erb
@@ -39,9 +39,7 @@
             <div class="text-center my-3">
                 <a href="/courses/new" id="import-courses-button" class="btn btn-secondary ">Import courses from Canvas</a>
             </div>
-            <div class="text-center">
-                <%= button_to 'Delete All Courses', delete_all_courses_path, method: :delete, class: 'btn btn-danger', data: { confirm: 'Are you sure you want to delete all your courses and associations?' } %>
-            </div>
+
         </div>
         <% end %>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -27,8 +27,6 @@ Rails.application.routes.draw do
       post :sync_assignments
       post :sync_enrollments
       get :enrollments
-    end
-    collection do
       delete :delete
     end
     resources :extensions, only: [:create]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -22,7 +22,6 @@ Rails.application.routes.draw do
   get '/courses/:id', to: 'courses#show', as: :course
   get '/courses/:id/edit', to: 'courses#edit', as: :course_settings
   
-  # Add the delete_all route for courses
   resources :courses do
     member do
       post :sync_assignments
@@ -30,7 +29,7 @@ Rails.application.routes.draw do
       get :enrollments
     end
     collection do
-      delete :delete_all
+      delete :delete
     end
     resources :extensions, only: [:create]
     resources :requests do

--- a/spec/controllers/courses_controller_spec.rb
+++ b/spec/controllers/courses_controller_spec.rb
@@ -112,14 +112,6 @@ RSpec.describe CoursesController, type: :controller do
     end
   end
 
-  describe 'POST #delete_all' do
-    it 'deletes user courses and redirects' do
-      delete :delete_all
-      expect(response).to redirect_to(courses_path)
-      expect(flash[:notice]).to eq('All your courses and associations have been deleted successfully.')
-    end
-  end
-
   describe 'GET #new' do
     before do
       # Create a fake LMS credential with a token

--- a/spec/controllers/courses_controller_spec.rb
+++ b/spec/controllers/courses_controller_spec.rb
@@ -222,3 +222,5 @@ RSpec.describe CoursesController, type: :controller do
     end
   end
 end
+
+1


### PR DESCRIPTION
# General Info
Removed delete all courses method. Replaced with delete course in course settings page.
Resolves #246 
