### PR TITLE
Implemented Slack Webhooks

### DIFF
--- a/app/controllers/course_settings_controller.rb
+++ b/app/controllers/course_settings_controller.rb
@@ -50,7 +50,9 @@ class CourseSettingsController < ApplicationController
       :enable_emails,
       :reply_email,
       :email_subject,
-      :email_template
+      :email_template,
+      :enable_slack_webhook_url,
+      :slack_webhook_url  
     )
   end
 

--- a/app/controllers/course_settings_controller.rb
+++ b/app/controllers/course_settings_controller.rb
@@ -25,8 +25,10 @@ class CourseSettingsController < ApplicationController
       reset_email_templates
       redirect_to course_settings_path(@course, tab: 'email'), notice: 'Email templates reset to defaults.'
     elsif @course_settings.update(course_settings_params)
-      # Use the tab from params to determine which tab to show
-      if @course_settings.enable_slack_webhook_url && @course_settings.slack_webhook_url.present?
+      if @course_settings.enable_slack_webhook_url &&
+         @course_settings.slack_webhook_url.present? &&
+         @course_settings.saved_change_to_slack_webhook_url?
+
         success = SlackNotifier.notify(
           ":wave: Slack notifications have been enabled for *#{@course.course_name}* (#{@course.course_code}). You will now receive updates here!",
           @course_settings.slack_webhook_url

--- a/app/controllers/course_settings_controller.rb
+++ b/app/controllers/course_settings_controller.rb
@@ -52,7 +52,7 @@ class CourseSettingsController < ApplicationController
       :email_subject,
       :email_template,
       :enable_slack_webhook_url,
-      :slack_webhook_url  
+      :slack_webhook_url
     )
   end
 

--- a/app/javascript/controllers/course_settings_controller.js
+++ b/app/javascript/controllers/course_settings_controller.js
@@ -1,36 +1,51 @@
 import { Controller } from "@hotwired/stimulus"
 
 export default class extends Controller {
-  static targets = ["emailField", "tab"]
-  
+  static targets = ["emailField", "tab", "slackWebhookField"]
+
   connect() {
     this.toggleEmailFields();
-    
+    this.toggleSlackWebhookField();
+
     const emailToggle = document.getElementById('enable-email');
     if (emailToggle) {
       emailToggle.addEventListener('change', this.toggleEmailFields.bind(this));
     }
+
+    const slackToggle = document.getElementById('enable-slack');
+    if (slackToggle) {
+      slackToggle.addEventListener('change', this.toggleSlackWebhookField.bind(this));
+    }
   }
-  
+
   toggleEmailFields() {
     const emailToggle = document.getElementById('enable-email');
     const replyEmailField = document.getElementById('reply-email');
-    
+
     if (emailToggle && replyEmailField) {
       const isEnabled = emailToggle.checked;
       replyEmailField.disabled = !isEnabled;
     }
   }
-  
+
+  toggleSlackWebhookField() {
+    const slackToggle = document.getElementById('enable-slack');
+    const slackWebhookField = document.getElementById('slack-webhook');
+
+    if (slackToggle && slackWebhookField) {
+      slackWebhookField.disabled = !slackToggle.checked;
+    }
+  }
+
   updateUrlParam(event) {
     const tabName = event.currentTarget.dataset.tab;
     const url = new URL(window.location);
     url.searchParams.set('tab', tabName);
     window.history.pushState({}, '', url);
-    
+
     const tabInput = document.getElementById('tab');
     if (tabInput) {
       tabInput.value = tabName;
     }
   }
-} 
+}

--- a/app/models/request.rb
+++ b/app/models/request.rb
@@ -28,10 +28,13 @@ class Request < ApplicationRecord
     notify_slack = false
     slack_message = nil
 
+    # Build the link using ENV and Rails routes
+    link = "#{ENV['CANVAS_REDIRECT_URI']}/courses/#{course.id}/requests/#{id}"
+
     if try_auto_approval(current_user)
       # Auto-approved
       notify_slack = true
-      slack_message = "A request was *auto-approved* for '#{assignment&.name}' (#{user&.name}) in course '#{course&.course_name}'."
+      slack_message = "A request was *auto-approved* for '#{assignment&.name}' (#{user&.name}) in course '#{course&.course_name}'.\nView: #{link}"
       result = {
         redirect_to: Rails.application.routes.url_helpers.course_request_path(course, id),
         notice: 'Your extension request has been approved.'
@@ -39,7 +42,7 @@ class Request < ApplicationRecord
     else
       # Pending
       notify_slack = true
-      slack_message = "A new extension request is *pending* for review: '#{assignment&.name}' (#{user&.name}) in course '#{course&.course_name}'."
+      slack_message = "A new extension request is *pending* for review: '#{assignment&.name}' (#{user&.name}) in course '#{course&.course_name}'.\nView: #{link}"
       result = {
         redirect_to: Rails.application.routes.url_helpers.course_request_path(course, id),
         notice: 'Your extension request has been submitted.'

--- a/app/models/request.rb
+++ b/app/models/request.rb
@@ -47,8 +47,10 @@ class Request < ApplicationRecord
       }
     end
 
-    SlackNotifier.notify(slack_message, course.course_settings.slack_webhook_url) if notify_slack && course&.course_settings&.slack_webhook_url.present?
-
+    success = SlackNotifier.notify(slack_message, course.course_settings.slack_webhook_url) if notify_slack && course&.course_settings&.slack_webhook_url.present?
+    if !success
+      result[:alert] = 'Failed to notify Slack. Please check your webhook URL.'
+    end
     result
   end
 
@@ -65,8 +67,10 @@ class Request < ApplicationRecord
       result = build_result_hash('Request was successfully updated.')
     end
 
-    SlackNotifier.notify(slack_message, course.course_settings.slack_webhook_url) if notify_slack && course&.course_settings&.slack_webhook_url.present?
-
+    success = SlackNotifier.notify(slack_message, course.course_settings.slack_webhook_url) if notify_slack && course&.course_settings&.slack_webhook_url.present?
+    if !success
+      result[:alert] = 'Failed to notify Slack. Please check your webhook URL.'
+    end
     result
   end
 

--- a/app/models/request.rb
+++ b/app/models/request.rb
@@ -47,8 +47,11 @@ class Request < ApplicationRecord
       }
     end
 
-    SlackNotifier.notify(slack_message, course.course_settings.slack_webhook_url) if notify_slack && course&.course_settings&.slack_webhook_url.present?
-
+    success = SlackNotifier.notify(slack_message, course.course_settings.slack_webhook_url) if notify_slack && course&.course_settings&.slack_webhook_url.present?
+    if !success:
+      Rails.logger.error "Failed to send Slack notification for request #{id} in course #{course.id}"
+      result[:alert] = 'Your request was created, but there was an issue sending the Slack notification.'
+    end
     result
   end
 
@@ -65,8 +68,11 @@ class Request < ApplicationRecord
       result = build_result_hash('Request was successfully updated.')
     end
 
-    SlackNotifier.notify(slack_message, course.course_settings.slack_webhook_url) if notify_slack && course&.course_settings&.slack_webhook_url.present?
-
+    success = SlackNotifier.notify(slack_message, course.course_settings.slack_webhook_url) if notify_slack && course&.course_settings&.slack_webhook_url.present?
+    if !success:
+      Rails.logger.error "Failed to send Slack notification for request #{id} in course #{course.id}"
+      result[:alert] = 'Your request was created, but there was an issue sending the Slack notification.'
+    end
     result
   end
 

--- a/app/models/request.rb
+++ b/app/models/request.rb
@@ -49,7 +49,7 @@ class Request < ApplicationRecord
 
     success = SlackNotifier.notify(slack_message, course.course_settings.slack_webhook_url) if notify_slack && course&.course_settings&.slack_webhook_url.present?
     if !success
-      result[:notice] ||= 'Your request was submitted, but we could not notify Slack. Please check your webhook URL.'
+      result[:notice] = 'Your request was submitted, but we could not notify Slack. Please check your webhook URL.'
     end
     result
   end
@@ -69,7 +69,7 @@ class Request < ApplicationRecord
 
     success = SlackNotifier.notify(slack_message, course.course_settings.slack_webhook_url) if notify_slack && course&.course_settings&.slack_webhook_url.present?
     if !success
-      result[:notice] ||= 'Your request was submitted, but we could not notify Slack. Please check your webhook URL.'
+      result[:notice] = 'Your request was submitted, but we could not notify Slack. Please check your webhook URL.'
     end
     result
   end

--- a/app/models/request.rb
+++ b/app/models/request.rb
@@ -47,11 +47,8 @@ class Request < ApplicationRecord
       }
     end
 
-    success = SlackNotifier.notify(slack_message, course.course_settings.slack_webhook_url) if notify_slack && course&.course_settings&.slack_webhook_url.present?
-    if !success:
-      Rails.logger.error "Failed to send Slack notification for request #{id} in course #{course.id}"
-      result[:alert] = 'Your request was created, but there was an issue sending the Slack notification.'
-    end
+    SlackNotifier.notify(slack_message, course.course_settings.slack_webhook_url) if notify_slack && course&.course_settings&.slack_webhook_url.present?
+
     result
   end
 
@@ -68,11 +65,8 @@ class Request < ApplicationRecord
       result = build_result_hash('Request was successfully updated.')
     end
 
-    success = SlackNotifier.notify(slack_message, course.course_settings.slack_webhook_url) if notify_slack && course&.course_settings&.slack_webhook_url.present?
-    if !success:
-      Rails.logger.error "Failed to send Slack notification for request #{id} in course #{course.id}"
-      result[:alert] = 'Your request was created, but there was an issue sending the Slack notification.'
-    end
+    SlackNotifier.notify(slack_message, course.course_settings.slack_webhook_url) if notify_slack && course&.course_settings&.slack_webhook_url.present?
+
     result
   end
 

--- a/app/models/request.rb
+++ b/app/models/request.rb
@@ -49,7 +49,7 @@ class Request < ApplicationRecord
 
     success = SlackNotifier.notify(slack_message, course.course_settings.slack_webhook_url) if notify_slack && course&.course_settings&.slack_webhook_url.present?
     if !success
-      result[:alert] = 'Failed to notify Slack. Please check your webhook URL.'
+      result[:notice] ||= 'Your request was submitted, but we could not notify Slack. Please check your webhook URL.'
     end
     result
   end
@@ -69,7 +69,7 @@ class Request < ApplicationRecord
 
     success = SlackNotifier.notify(slack_message, course.course_settings.slack_webhook_url) if notify_slack && course&.course_settings&.slack_webhook_url.present?
     if !success
-      result[:alert] = 'Failed to notify Slack. Please check your webhook URL.'
+      result[:notice] ||= 'Your request was submitted, but we could not notify Slack. Please check your webhook URL.'
     end
     result
   end
@@ -140,7 +140,8 @@ class Request < ApplicationRecord
 
   def reject(processed_user_id)
     update(status: 'denied', last_processed_by_user_id: processed_user_id.id)
-    send_email_response if course.course_settings&.enable_emails
+    # Only send email if the person processing is the same as the request's user
+    send_email_response if course.course_settings&.enable_emails && processed_user_id.id != user_id
     true
   end
 

--- a/app/services/slack_notifier.rb
+++ b/app/services/slack_notifier.rb
@@ -4,7 +4,7 @@ require 'json'
 
 class SlackNotifier
   def self.notify(text, webhook_url)
-    return unless webhook_url.present?
+    return if webhook_url.blank?
 
     uri = URI.parse(webhook_url)
     header = { 'Content-Type': 'application/json' }

--- a/app/services/slack_notifier.rb
+++ b/app/services/slack_notifier.rb
@@ -22,7 +22,7 @@ class SlackNotifier
     end
 
     true
-  rescue => e
+  rescue StandardError => e
     Rails.logger.error("SlackNotifier exception: #{e.class} - #{e.message}")
     false
   end

--- a/app/services/slack_notifier.rb
+++ b/app/services/slack_notifier.rb
@@ -1,0 +1,19 @@
+require 'net/http'
+require 'uri'
+require 'json'
+
+class SlackNotifier
+  def self.notify(text, webhook_url)
+    return unless webhook_url.present?
+
+    uri = URI.parse(webhook_url)
+    header = { 'Content-Type': 'application/json' }
+    payload = { text: text }
+
+    http = Net::HTTP.new(uri.host, uri.port)
+    http.use_ssl = true
+    request = Net::HTTP::Post.new(uri.request_uri, header)
+    request.body = payload.to_json
+    http.request(request)
+  end
+end

--- a/app/services/slack_notifier.rb
+++ b/app/services/slack_notifier.rb
@@ -14,6 +14,16 @@ class SlackNotifier
     http.use_ssl = true
     request = Net::HTTP::Post.new(uri.request_uri, header)
     request.body = payload.to_json
-    http.request(request)
+    response = http.request(request)
+
+    unless response.is_a?(Net::HTTPSuccess)
+      Rails.logger.error("SlackNotifier failed: #{response.code} #{response.message} - #{response.body}")
+      return false
+    end
+
+    true
+  rescue => e
+    Rails.logger.error("SlackNotifier exception: #{e.class} - #{e.message}")
+    false
   end
 end

--- a/app/services/slack_notifier.rb
+++ b/app/services/slack_notifier.rb
@@ -14,16 +14,6 @@ class SlackNotifier
     http.use_ssl = true
     request = Net::HTTP::Post.new(uri.request_uri, header)
     request.body = payload.to_json
-    response = http.request(request)
-
-    unless response.is_a?(Net::HTTPSuccess)
-      Rails.logger.error("SlackNotifier failed: #{response.code} #{response.message} - #{response.body}")
-      return false
-    end
-
-    true
-  rescue => e
-    Rails.logger.error("SlackNotifier exception: #{e.class} - #{e.message}")
-    false
+    http.request(request)
   end
 end

--- a/app/views/courses/edit.html.erb
+++ b/app/views/courses/edit.html.erb
@@ -123,6 +123,31 @@
                                 </div>
 
                                 <div class="mb-3">
+                                    <div class="form-check form-switch">
+                                        <%= hidden_field_tag 'course_settings[enable_slack_webhook_url]', false %>
+                                        <%= check_box_tag 'course_settings[enable_slack_webhook_url]', 
+                                                         true, 
+                                                         @course.course_settings&.enable_slack_webhook_url, 
+                                                         class: 'form-check-input', 
+                                                         id: 'enable-slack' %>
+                                        <label class="form-check-label" for="enable-slack">Enable Slack Notifications</label>
+                                    </div>
+                                </div>
+
+                                <div class="mb-3 row border-bottom pb-3">
+                                    <label for="slack-webhook" class="col-sm-4 col-form-label">Slack Webhook URL</label>
+                                    <div class="col-sm-8">
+                                        <%= text_field_tag 'course_settings[slack_webhook_url]',
+                                                          @course.course_settings&.slack_webhook_url,
+                                                          class: 'form-control',
+                                                          id: 'slack-webhook',
+                                                          placeholder: 'https://hooks.slack.com/services/...',
+                                                          data: { course_settings_target: "slackWebhookField" },
+                                                          disabled: !@course.course_settings&.enable_slack_webhook_url %>
+                                    </div>
+                                </div>
+
+                                <div class="mb-3">
                                     <div class="text-start">
                                         <% if @course.course_settings&.enable_extensions %>
                                             <%= link_to 'Delete Course (must have student extension requests disabled)', '#', class: 'btn btn-outline-danger disable me-3', aria_disabled: 'true' %>

--- a/db/migrate/20250525035134_add_slack_webhook_url_to_course_settings.rb
+++ b/db/migrate/20250525035134_add_slack_webhook_url_to_course_settings.rb
@@ -1,0 +1,5 @@
+class AddSlackWebhookUrlToCourseSettings < ActiveRecord::Migration[7.1]
+  def change
+    add_column :course_settings, :slack_webhook_url, :string
+  end
+end

--- a/db/migrate/20250525040653_add_enable_slack_webhook_url_to_course_settings.rb
+++ b/db/migrate/20250525040653_add_enable_slack_webhook_url_to_course_settings.rb
@@ -1,0 +1,5 @@
+class AddEnableSlackWebhookUrlToCourseSettings < ActiveRecord::Migration[7.1]
+  def change
+    add_column :course_settings, :enable_slack_webhook_url, :boolean
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2025_04_22_073255) do
+ActiveRecord::Schema[7.1].define(version: 2025_05_25_040653) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -42,6 +42,8 @@ ActiveRecord::Schema[7.1].define(version: 2025_04_22_073255) do
     t.text "email_template", default: "Dear {{student_name}},\n\nYour extension request for {{assignment_name}} in {{course_name}} ({{course_code}}) has been {{status}}.\n\nExtension Details:\n- Original Due Date: {{original_due_date}}\n- New Due Date: {{new_due_date}}\n- Extension Days: {{extension_days}}\n\nIf you have any questions, please contact the course staff.\n\nBest regards,\n{{course_name}} Staff"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "slack_webhook_url"
+    t.boolean "enable_slack_webhook_url", default: false
     t.index ["course_id"], name: "index_course_settings_on_course_id"
   end
 


### PR DESCRIPTION
Creates a Slack Notification in Slack Webhook Channel Specified in Course Settings.

To get the Slack Webhook URL for a specific channel, create a Flextensions app for the Slack Workspace. 
(URL should be something like https://api.slack.com/apps/:app_id/incoming-webhooks)

Navigate to "Incoming Webhooks" in the app features. Enable "Activate Incoming Webhooks". Click "Add New Webhook" and specify the channel. In the Course Settings Page for flextensions, enable Slack Notifications and copy and paste the generated Webhook URL into the Slack Webhook URL. After clicking save settings, if the Webhook is valid, there should be notification in the Slack Channel with a Welcome Message. Otherwise, the an alert telling you to check the Webhook to make sure its correct appears.

After correctly setting up the Webhook, actions related to requests should generate a Slack Notification in the specified channel with a link to the corresponding request.