### PR TITLE
Add semester filter to Import Courses page

### DIFF
--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -38,12 +38,21 @@ class CoursesController < ApplicationController
     @courses = Course.fetch_courses(token)
     flash[:alert] = 'No courses found.' if @courses.empty?
 
+    # Collect unique semester names from Canvas term data for the filter dropdown
+    @semesters = @courses.filter_map { |c| c.dig('term', 'name') }.uniq.sort
+    @selected_semester = params[:semester]
+
     teacher_enrollment_types = %w[teacher ta]
     # TODO: Add spec for when a course is created, but the user is not enrolled in it.
     # TODO: Why do some courses have empty enrollments?
     existing_canvas_ids = @user.courses.pluck(:canvas_id)
     @courses_teacher = filter_courses(@courses, teacher_enrollment_types, existing_canvas_ids)
     @courses_student = filter_courses(@courses, [ 'student' ], existing_canvas_ids)
+
+    if @selected_semester.present?
+      @courses_teacher = filter_by_semester(@courses_teacher, @selected_semester)
+      @courses_student = filter_by_semester(@courses_student, @selected_semester)
+    end
   end
 
   def edit
@@ -105,6 +114,11 @@ class CoursesController < ApplicationController
 
   def determine_user_role
     @role = @course&.user_role(@user)
+  end
+
+  # Filters Canvas API course hashes by their term name
+  def filter_by_semester(courses, semester)
+    courses.select { |c| c.dig('term', 'name') == semester }
   end
 
   # TODO: This should be moved to the Canvas Facade

--- a/app/facades/canvas_facade.rb
+++ b/app/facades/canvas_facade.rb
@@ -195,7 +195,7 @@ class CanvasFacade < LmsFacade
   # @param  [Integer] courseId the course id to look up.
   # @return [Faraday::Response] information about the requested course.
   def get_course(courseId)
-    @canvas_conn.get("courses/#{courseId}")
+    @canvas_conn.get("courses/#{courseId}", { 'include[]': 'term' })
   end
 
   ##

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -35,6 +35,9 @@ class Course < ApplicationRecord
   validates :course_name, presence: true
   # validate :ensure_course_settings
 
+  # Scopes
+  scope :by_semester, ->(semester) { where(semester: semester) }
+
   # Always load the LMS integrations
   default_scope { includes(:course_to_lmss) }
 
@@ -198,6 +201,8 @@ class Course < ApplicationRecord
     response_data = JSON.parse(response.body)
     course.course_name = response_data['name']
     course.course_code = response_data['course_code']
+    # Semester is sourced from the Canvas term name (e.g. "Spring 2026")
+    course.semester = response_data.dig('term', 'name')
     course.save!
     course
   end

--- a/app/views/courses/new.html.erb
+++ b/app/views/courses/new.html.erb
@@ -11,6 +11,17 @@
       <h2 class="mb-4">Choose courses to set up extensions with:</h2>
       <p>If you expect to see a class, but it is not listed, ensure the Course is not already setup with Flextensions and that its corresponding Canvas course is active.</p>
     </div>
+    <% if @semesters.any? %>
+      <div class="col-12 mb-3">
+        <%= form_with url: new_course_path, method: :get, local: true, class: "d-inline-flex align-items-center gap-2" do %>
+          <label for="semester" class="form-label mb-0 fw-bold">Semester:</label>
+          <%= select_tag :semester,
+              options_for_select([["All Semesters", ""]] + @semesters.map { |s| [s, s] }, @selected_semester),
+              class: "form-select form-select-sm", style: "width: auto;",
+              onchange: "this.form.submit();" %>
+        <% end %>
+      </div>
+    <% end %>
     <% if @courses_teacher.any? %>
       <%= form_with url: courses_path, method: :post, class: "mt-3" do %>
         <table class="table table-bordered table-striped" id="import-course-table">
@@ -32,7 +43,7 @@
                     <label class="form-check-label" for="assignment-1-has-partner"></label>
                   </div>
                 </td>
-                <td><%= DateTime.parse(course["created_at"]).strftime("%B %Y") %></td>
+                <td><%= course.dig("term", "name") %></td>
                 <td><%= course["course_code"] %></td>
                 <td><%= course["name"] %></td>
                 <td><%= course['enrollments'].find { |enrollment| %w[teacher ta].include?(enrollment['type']) }['type'].capitalize %></td>
@@ -54,7 +65,7 @@
           <% @courses_student.sort_by { |c| DateTime.parse(c["created_at"]) }.reverse.each do |course| %>
             <div class="mb-3">
               <span>
-                <strong>Semester:</strong> <%= DateTime.parse(course["created_at"]).strftime("%B %Y") %> |
+                <strong>Semester:</strong> <%= course.dig("term", "name") %> |
                 <strong>Course:</strong> <%= course["course_code"] %> |
                 <strong>Name:</strong> <%= course["name"] %> |
                 <strong>Role:</strong> <%= course['enrollments'].find { |enrollment| %w[student observer designer].include?(enrollment['type']) }['type'].capitalize %>

--- a/app/views/requests/instructor_index.html.erb
+++ b/app/views/requests/instructor_index.html.erb
@@ -22,6 +22,7 @@
         <table class="table table-bordered table-striped datatable"
                id="requests-table"
                data-controller="requests"
+               data-search-query="<%= @search_query %>"
                data-readonly-token="<%= @course.readonly_api_token %>"
                data-course-id="<%= @course.id %>">
           <thead>

--- a/db/migrate/20260306000001_add_semester_to_courses.rb
+++ b/db/migrate/20260306000001_add_semester_to_courses.rb
@@ -1,0 +1,5 @@
+class AddSemesterToCourses < ActiveRecord::Migration[7.2]
+  def change
+    add_column :courses, :semester, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2026_02_02_000001) do
+ActiveRecord::Schema[7.2].define(version: 2026_03_06_000001) do
   create_schema "hypershield"
 
   # These are extensions that must be enabled in order to support this database
@@ -127,6 +127,7 @@ ActiveRecord::Schema[7.2].define(version: 2026_02_02_000001) do
     t.string "canvas_id"
     t.string "course_code"
     t.string "readonly_api_token"
+    t.string "semester"
     t.index ["canvas_id"], name: "index_courses_on_canvas_id", unique: true
     t.index ["readonly_api_token"], name: "index_courses_on_readonly_api_token", unique: true
   end

--- a/features/enrollments.feature
+++ b/features/enrollments.feature
@@ -14,7 +14,8 @@ Feature: Course Enrollments
 
 	@javascript
 	Scenario: Clicking a student name on Enrollments navigates to filtered requests
-		Given I'm logged in as a teacher
+		Given a request exists for student "User 3"
+		And I'm logged in as a teacher
 		When I go to the Course Enrollments page
 		And I click the name link for student "User 3"
 		Then I should be on the "Requests page" with param show_all=true

--- a/features/enrollments.feature
+++ b/features/enrollments.feature
@@ -11,3 +11,11 @@ Feature: Course Enrollments
 		And I should see "User 3"
 		And I should see "User 4"
 		And I should see "User 5"
+
+	@javascript
+	Scenario: Clicking a student name on Enrollments navigates to filtered requests
+		Given I'm logged in as a teacher
+		When I go to the Course Enrollments page
+		And I click the name link for student "User 3"
+		Then I should be on the "Requests page" with param show_all=true
+		And the requests table search should be filtered

--- a/features/step_definitions/custom_steps.rb
+++ b/features/step_definitions/custom_steps.rb
@@ -148,6 +148,26 @@ end
 
 # Stubbing the Deny controller
 # Given I deny the request for "Homework 3"
+# Create a request for a specific student using factory data
+Given(/^a request exists for student "([^"]*)"$/) do |student_name|
+  student = User.find_by(name: student_name)
+  assignment = Assignment.first
+  create(:request, user: student, course: @course, assignment: assignment)
+end
+
+# Click a specific student's name link on the enrollments page
+When(/^I click the name link for student "([^"]*)"$/) do |student_name|
+  within('#enrollments-table') do
+    click_link student_name
+  end
+end
+
+# Verify the DataTable search input has a value (i.e., filter is active)
+Then(/^the requests table search should be filtered$/) do
+  search_input = find('.dt-search input')
+  expect(search_input.value).not_to be_empty
+end
+
 Given(/^I deny the request for "([^"]*)"$/) do |assignment_name|
   request = Request.joins(:assignment)
                    .find_by(assignments: { name: assignment_name }, status: 'pending')

--- a/lib/tasks/backfill_course_semester.rake
+++ b/lib/tasks/backfill_course_semester.rake
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+namespace :courses do
+  desc 'Backfill semester for existing courses by fetching term data from Canvas'
+  task backfill_semester: :environment do
+    puts 'Starting backfill of semester for all courses...'
+
+    total = Course.count
+    updated_count = 0
+    skipped_count = 0
+    failed_count = 0
+
+    Course.find_each do |course|
+      if course.semester.present?
+        skipped_count += 1
+        next
+      end
+
+      # Find a staff user with Canvas credentials to make the API call
+      staff_user = course.staff_user_for_auto_approval
+      if staff_user.nil?
+        puts "No staff user found for course #{course.id} (#{course.course_name}) - skipping"
+        failed_count += 1
+        next
+      end
+
+      token = staff_user.canvas_token
+      if token.blank?
+        puts "No Canvas token for staff user on course #{course.id} (#{course.course_name}) - skipping"
+        failed_count += 1
+        next
+      end
+
+      begin
+        response = CanvasFacade.new(token).get_course(course.canvas_id)
+        if response&.success?
+          data = JSON.parse(response.body)
+          semester = data.dig('term', 'name')
+          if semester.present?
+            course.update!(semester: semester)
+            updated_count += 1
+            puts "Updated course #{course.id} (#{course.course_name}) -> #{semester}"
+          else
+            puts "No term data for course #{course.id} (#{course.course_name}) - skipping"
+            failed_count += 1
+          end
+        else
+          puts "API request failed for course #{course.id} (#{course.course_name}) - skipping"
+          failed_count += 1
+        end
+      rescue StandardError => e
+        puts "Error for course #{course.id} (#{course.course_name}): #{e.message}"
+        failed_count += 1
+      end
+    end
+
+    puts "\nBackfill complete!"
+    puts "Total courses: #{total}"
+    puts "Updated: #{updated_count}"
+    puts "Skipped (already set): #{skipped_count}"
+    puts "Failed: #{failed_count}"
+  end
+end

--- a/spec/controllers/courses_controller_spec.rb
+++ b/spec/controllers/courses_controller_spec.rb
@@ -116,24 +116,44 @@ RSpec.describe CoursesController, type: :controller do
   end
 
   describe 'GET #new' do
+    let(:canvas_courses) do
+      [
+        {
+          'id' => '101',
+          'name' => 'Test Course 101',
+          'course_code' => 'TC101',
+          'enrollments' => [ { 'type' => 'teacher' } ],
+          'term' => { 'name' => 'Spring 2026' }
+        },
+        {
+          'id' => '102',
+          'name' => 'Test Course 102',
+          'course_code' => 'TC102',
+          'enrollments' => [ { 'type' => 'student' } ],
+          'term' => { 'name' => 'Spring 2026' }
+        },
+        {
+          'id' => '103',
+          'name' => 'Test Course 103',
+          'course_code' => 'TC103',
+          'enrollments' => [ { 'type' => 'teacher' } ],
+          'term' => { 'name' => 'Fall 2025' }
+        },
+        {
+          'id' => '104',
+          'name' => 'Test Course 104',
+          'course_code' => 'TC104',
+          'enrollments' => [ { 'type' => 'student' } ],
+          'term' => { 'name' => 'Fall 2025' }
+        }
+      ]
+    end
+
     before do
       # Create a fake LMS credential with a token
       user.lms_credentials.create!(lms_name: 'canvas', token: 'fake_token', expire_time: 1.hour.from_now)
 
-      allow(Course).to receive(:fetch_courses).and_return([
-                                                            {
-                                                              'id' => '101',
-                                                              'name' => 'Test Course 101',
-                                                              'course_code' => 'TC101',
-                                                              'enrollments' => [ { 'type' => 'teacher' } ]
-                                                            },
-                                                            {
-                                                              'id' => '102',
-                                                              'name' => 'Test Course 102',
-                                                              'course_code' => 'TC102',
-                                                              'enrollments' => [ { 'type' => 'student' } ]
-                                                            }
-                                                          ])
+      allow(Course).to receive(:fetch_courses).and_return(canvas_courses)
     end
 
     it 'fetches courses and categorizes them into teacher and student courses' do
@@ -161,6 +181,44 @@ RSpec.describe CoursesController, type: :controller do
       get :new
 
       expect(flash[:alert]).to eq('No courses found.')
+    end
+
+    describe 'semester filter' do
+      it 'extracts unique semesters from Canvas courses' do
+        get :new
+
+        expect(assigns(:semesters)).to contain_exactly('Fall 2025', 'Spring 2026')
+      end
+
+      it 'shows all courses when no semester param is provided' do
+        get :new
+
+        expect(assigns(:courses_teacher).size).to eq(2)
+        expect(assigns(:courses_student).size).to eq(2)
+        expect(assigns(:selected_semester)).to be_nil
+      end
+
+      it 'filters teacher courses by selected semester' do
+        get :new, params: { semester: 'Spring 2026' }
+
+        teacher_names = assigns(:courses_teacher).map { |c| c['name'] }
+        expect(teacher_names).to eq([ 'Test Course 101' ])
+        expect(teacher_names).not_to include('Test Course 103')
+      end
+
+      it 'filters student courses by selected semester' do
+        get :new, params: { semester: 'Fall 2025' }
+
+        student_names = assigns(:courses_student).map { |c| c['name'] }
+        expect(student_names).to eq([ 'Test Course 104' ])
+        expect(student_names).not_to include('Test Course 102')
+      end
+
+      it 'assigns the selected semester' do
+        get :new, params: { semester: 'Spring 2026' }
+
+        expect(assigns(:selected_semester)).to eq('Spring 2026')
+      end
     end
   end
 

--- a/spec/controllers/requests_controller_spec.rb
+++ b/spec/controllers/requests_controller_spec.rb
@@ -51,6 +51,26 @@ RSpec.describe RequestsController, type: :controller do
       expect(response).to have_http_status(:ok)
       expect(response).to render_template('requests/instructor_index')
     end
+
+    it 'assigns @search_query from params[:search]' do
+      session[:user_id] = instructor.canvas_uid
+      UserToCourse.create!(user: instructor, course: teacher_course, role: 'teacher')
+      FormSetting.create!(course: teacher_course, documentation_disp: 'hidden', custom_q1_disp: 'hidden', custom_q2_disp: 'hidden')
+
+      get :index, params: { course_id: teacher_course.id, search: '12345', show_all: 'true' }
+
+      expect(assigns(:search_query)).to eq('12345')
+    end
+
+    it 'assigns @search_query as nil when no search param is provided' do
+      session[:user_id] = instructor.canvas_uid
+      UserToCourse.create!(user: instructor, course: teacher_course, role: 'teacher')
+      FormSetting.create!(course: teacher_course, documentation_disp: 'hidden', custom_q1_disp: 'hidden', custom_q2_disp: 'hidden')
+
+      get :index, params: { course_id: teacher_course.id }
+
+      expect(assigns(:search_query)).to be_nil
+    end
   end
 
   describe 'GET #show' do

--- a/spec/factories/courses.rb
+++ b/spec/factories/courses.rb
@@ -20,6 +20,7 @@ FactoryBot.define do
     sequence(:course_name) { |n| "Course #{n}" }
     sequence(:canvas_id, &:to_s)
     sequence(:course_code) { |n| "COURSE#{n}" }
+    semester { 'Spring 2026' }
 
     after(:create) do |course|
       lms = Lms.find_by(id: 1) || create(:lms, id: 1, lms_name: 'Canvas')

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -105,6 +105,44 @@ RSpec.describe Course, type: :model do
       expect(course.course_name).to eq('Intro to RSpec')
       expect(course.course_code).to eq('RSPEC101')
     end
+
+    it 'stores semester from Canvas term data' do
+      stub_request(:get, %r{api/v1/courses/canvas_123})
+        .to_return(status: 200, body: {
+          name: 'Intro to RSpec',
+          course_code: 'RSPEC101',
+          term: { name: 'Spring 2026' }
+        }.to_json)
+
+      course = described_class.find_or_create_course(course_data, token)
+
+      expect(course.semester).to eq('Spring 2026')
+    end
+
+    it 'handles missing term data gracefully' do
+      stub_request(:get, %r{api/v1/courses/canvas_123})
+        .to_return(status: 200, body: { name: 'Intro to RSpec', course_code: 'RSPEC101' }.to_json)
+
+      course = described_class.find_or_create_course(course_data, token)
+
+      expect(course.semester).to be_nil
+    end
+
+    it 'updates semester on existing course when Canvas term changes' do
+      described_class.create!(canvas_id: 'canvas_123', course_name: 'Intro to RSpec',
+                              course_code: 'RSPEC101', semester: 'Fall 2025')
+
+      stub_request(:get, %r{api/v1/courses/canvas_123})
+        .to_return(status: 200, body: {
+          name: 'Intro to RSpec',
+          course_code: 'RSPEC101',
+          term: { name: 'Spring 2026' }
+        }.to_json)
+
+      course = described_class.find_or_create_course(course_data, token)
+
+      expect(course.semester).to eq('Spring 2026')
+    end
   end
 
   describe '.find_or_create_course_to_lms' do
@@ -138,6 +176,19 @@ end
       end.to change(User, :count).by(CANVAS_USERS.size).and(
         change(UserToCourse, :count).by(CANVAS_USERS.size)
       )
+    end
+  end
+
+  describe '.by_semester' do
+    it 'returns only courses matching the given semester' do
+      spring = described_class.create!(canvas_id: 'c1', course_name: 'Course A', course_code: 'A', semester: 'Spring 2026')
+      fall = described_class.create!(canvas_id: 'c2', course_name: 'Course B', course_code: 'B', semester: 'Fall 2025')
+      described_class.create!(canvas_id: 'c3', course_name: 'Course C', course_code: 'C', semester: nil)
+
+      results = described_class.by_semester('Spring 2026')
+
+      expect(results).to contain_exactly(spring)
+      expect(results).not_to include(fall)
     end
   end
 


### PR DESCRIPTION
## Changes
- Added semester filter dropdown to the Import Courses page to filter courses by Canvas term
- Added `filter_by_semester` method to CoursesController to filter Canvas API course data by term name
- Updated course table to display semester from Canvas term data instead of creation date
- Collects unique semester names from Canvas API response for the filter dropdown

## Testing
- Run `bundle exec rspec spec/controllers/courses_controller_spec.rb` for semester filter tests
- Run the full rspec test suite to verify no regressions

## Documentation
No documentation needed

## Checklist
- [x] Name of branch corresponds to story
- [x] 80%+ test coverage with all tests passing