### PR TITLE
Add Enable All / Disable All assignments bulk action (#273)

### DIFF
--- a/app/controllers/assignments_controller.rb
+++ b/app/controllers/assignments_controller.rb
@@ -17,4 +17,38 @@ class AssignmentsController < ApplicationController
       render json: { redirect_to: course_path(course) }, status: :unprocessable_content
     end
   end
+
+  def bulk_update_enabled
+    course = Course.find_by(id: params[:course_id])
+    unless course
+      return render json: { error: 'Course not found.' }, status: :not_found
+    end
+
+    @role = params[:role] || course.user_role(@user)
+
+    unless @role == 'instructor'
+      Rails.logger.error "Role #{@role} does not have permission to bulk toggle assignment enabled status"
+      flash.now[:alert] = 'You do not have permission to perform this action.'
+      return render json: { redirect_to: course_path(course) }, status: :forbidden
+    end
+
+    enabled = ActiveModel::Type::Boolean.new.cast(params[:enabled])
+
+    scope = course.assignments
+    if enabled
+      eligible_scope = scope.where.not(due_date: nil)
+      updated_count = eligible_scope.update_all(enabled: true)
+      skipped_count = scope.count - updated_count
+    else
+      updated_count = scope.update_all(enabled: false)
+      skipped_count = 0
+    end
+
+    render json: {
+      success: true,
+      enabled: enabled,
+      updated_count: updated_count,
+      skipped_count: skipped_count
+    }, status: :ok
+  end
 end

--- a/app/javascript/controllers/assignment_controller.js
+++ b/app/javascript/controllers/assignment_controller.js
@@ -6,7 +6,12 @@ import "datatables.net-responsive-bs5";
 // Connects to data-controller="assignment"
 export default class extends Controller {
   static targets = ["checkbox"]
-  static values = { courseId: Number }
+  static values = {
+    courseId: Number,
+    bulkUrl: String,
+    role: String,
+    userId: Number
+  }
 
   connect() {
     this.checkboxTargets.forEach((checkbox) => {
@@ -62,6 +67,60 @@ export default class extends Controller {
       console.error("Error updating assignment:", error);
       checkbox.checked = !enabled; // rollback checkbox if error
     }
+  }
+
+  enableAll(event) {
+    if (!confirm("Enable all assignments for this course? Assignments without a due date will be skipped.")) return;
+    this._bulkUpdate(event.currentTarget, true);
+  }
+
+  disableAll(event) {
+    if (!confirm("Disable all assignments for this course?")) return;
+    this._bulkUpdate(event.currentTarget, false);
+  }
+
+  _bulkUpdate(button, enabled) {
+    const url = this.bulkUrlValue;
+    if (!url) {
+      console.error("bulk-url-value is not set on the assignment controller element");
+      return;
+    }
+    button.disabled = true;
+    const token = document.querySelector('meta[name="csrf-token"]').content;
+    fetch(url, {
+      method: "PATCH",
+      headers: {
+        "Content-Type": "application/json",
+        "X-CSRF-Token": token,
+      },
+      body: JSON.stringify({
+        course_id: this.courseIdValue,
+        enabled: enabled,
+        role: this.hasRoleValue ? this.roleValue : undefined,
+        user_id: this.hasUserIdValue ? this.userIdValue : undefined,
+      }),
+    })
+      .then(async (response) => {
+        const data = await response.json();
+        if (!response.ok) {
+          if (data.redirect_to) {
+            window.location.href = data.redirect_to;
+            return;
+          }
+          throw new Error(data.error || "Failed to update assignments.");
+        }
+        const action = enabled ? "enabled" : "disabled";
+        let message = `${data.updated_count} assignment(s) ${action}.`;
+        if (data.skipped_count && data.skipped_count > 0) {
+          message += ` ${data.skipped_count} skipped (missing due date).`;
+        }
+        flash("notice", message);
+        location.reload();
+      })
+      .catch((error) => {
+        flash("alert", error.message || "An error occurred while updating assignments.");
+        button.disabled = false;
+      });
   }
 
   sync(event) {

--- a/app/views/courses/instructor_show.html.erb
+++ b/app/views/courses/instructor_show.html.erb
@@ -49,11 +49,22 @@
           </tbody>
         </table>
       </div>
-      <div class="text-center">
+      <div class="text-center d-flex justify-content-center gap-2 flex-wrap"
+           data-controller="assignment"
+           data-assignment-course-id-value="<%= @course.id %>"
+           data-assignment-bulk-url-value="<%= bulk_update_enabled_assignments_path %>"
+           data-assignment-role-value="<%= @role %>"
+           data-assignment-user-id-value="<%= @user.id %>">
+        <button class="btn btn-success"
+                data-action="click->assignment#enableAll">
+          Enable All Assignments
+        </button>
+        <button class="btn btn-outline-secondary"
+                data-action="click->assignment#disableAll">
+          Disable All Assignments
+        </button>
         <button class="btn btn-info"
-                data-controller="assignment"
-                data-action="click->assignment#sync"
-                data-assignment-course-id-value="<%= @course.id %>">
+                data-action="click->assignment#sync">
           Sync Assignments
         </button>
       </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -60,6 +60,9 @@ Rails.application.routes.draw do
     member do
       patch :toggle_enabled
     end
+    collection do
+      patch :bulk_update_enabled
+    end
   end
 
   namespace :api do

--- a/features/assignments.feature
+++ b/features/assignments.feature
@@ -16,3 +16,9 @@ Feature: Course Assignments
 		And I go to the Course page
 		Then I should not see "Homework 1"
 		Then I should see "Homework 2"
+
+	Scenario: Instructor sees Enable All and Disable All buttons on the course page
+		Given I'm logged in as a teacher
+		When I go to the Course page
+		Then I should see "Enable All Assignments"
+		And I should see "Disable All Assignments"

--- a/spec/controllers/assignments_controller_spec.rb
+++ b/spec/controllers/assignments_controller_spec.rb
@@ -96,4 +96,91 @@ RSpec.describe AssignmentsController, type: :controller do
       end
     end
   end
+
+  describe 'PATCH #bulk_update_enabled' do
+    let!(:user) { User.create!(name: 'Test User', email: 'bulk-test@example.com') }
+    let!(:course) { Course.create!(course_name: 'Bulk Test Course', canvas_id: '456') }
+    let!(:course_to_lms) { CourseToLms.create!(course: course, lms_id: 1, external_course_id: '456') }
+    let!(:course_settings) { CourseSettings.create!(course: course, enable_extensions: true) }
+    let!(:assignment_with_due_date) do
+      Assignment.create!(
+        name: 'Assignment With Due Date',
+        course_to_lms: course_to_lms,
+        due_date: 3.days.from_now,
+        external_assignment_id: 'with-date-1',
+        enabled: false
+      )
+    end
+    let!(:another_assignment_with_due_date) do
+      Assignment.create!(
+        name: 'Another Assignment With Due Date',
+        course_to_lms: course_to_lms,
+        due_date: 5.days.from_now,
+        external_assignment_id: 'with-date-2',
+        enabled: false
+      )
+    end
+    let!(:assignment_without_due_date) do
+      Assignment.create!(
+        name: 'Assignment Without Due Date',
+        course_to_lms: course_to_lms,
+        due_date: nil,
+        external_assignment_id: 'no-date-1',
+        enabled: false
+      )
+    end
+
+    context 'when the user is an instructor' do
+      it 'enables all assignments with a due date and skips those without' do
+        patch :bulk_update_enabled, params: { course_id: course.id, enabled: true, role: 'instructor', user_id: user.id }
+
+        expect(response).to have_http_status(:ok)
+        body = JSON.parse(response.body)
+        expect(body['success']).to be true
+        expect(body['enabled']).to be true
+        expect(body['updated_count']).to eq(2)
+        expect(body['skipped_count']).to eq(1)
+
+        expect(assignment_with_due_date.reload.enabled).to be true
+        expect(another_assignment_with_due_date.reload.enabled).to be true
+        expect(assignment_without_due_date.reload.enabled).to be false
+      end
+
+      it 'disables all assignments regardless of due date' do
+        assignment_with_due_date.update!(enabled: true)
+        another_assignment_with_due_date.update!(enabled: true)
+
+        patch :bulk_update_enabled, params: { course_id: course.id, enabled: false, role: 'instructor', user_id: user.id }
+
+        expect(response).to have_http_status(:ok)
+        body = JSON.parse(response.body)
+        expect(body['success']).to be true
+        expect(body['enabled']).to be false
+        expect(body['updated_count']).to eq(3)
+        expect(body['skipped_count']).to eq(0)
+
+        expect(assignment_with_due_date.reload.enabled).to be false
+        expect(another_assignment_with_due_date.reload.enabled).to be false
+        expect(assignment_without_due_date.reload.enabled).to be false
+      end
+    end
+
+    context 'when the user is not an instructor' do
+      it 'returns a forbidden status and does not change any assignments' do
+        patch :bulk_update_enabled, params: { course_id: course.id, enabled: true, role: 'student', user_id: user.id }
+
+        expect(response).to have_http_status(:forbidden)
+        expect(assignment_with_due_date.reload.enabled).to be false
+        expect(another_assignment_with_due_date.reload.enabled).to be false
+      end
+    end
+
+    context 'when the course does not exist' do
+      it 'returns a not found status' do
+        patch :bulk_update_enabled, params: { course_id: -1, enabled: true, role: 'instructor', user_id: user.id }
+
+        expect(response).to have_http_status(:not_found)
+      end
+    end
+  end
 end


### PR DESCRIPTION
Closes #273.

## Summary
- Adds **Enable All Assignments** and **Disable All Assignments** buttons to the instructor course view, alongside the existing Sync button.
- New `PATCH /assignments/bulk_update_enabled` collection route, backed by `AssignmentsController#bulk_update_enabled`. The action is instructor-only and returns JSON with `updated_count` and `skipped_count`.
- When enabling, assignments without a `due_date` are skipped so the existing `enabled_requires_date_present` validation isn't tripped; the skip count is reported back in the flash so instructors know what happened.
- Front-end wiring lives in `assignment_controller.js` (`enableAll` / `disableAll`), reusing the existing CSRF + flash + reload pattern from `sync`.

## Files changed
- `config/routes.rb` — add `collection { patch :bulk_update_enabled }` on `resources :assignments`
- `app/controllers/assignments_controller.rb` — add `bulk_update_enabled`
- `app/views/courses/instructor_show.html.erb` — add the two buttons and lift `data-controller="assignment"` to a wrapper with the new values
- `app/javascript/controllers/assignment_controller.js` — `enableAll`, `disableAll`, `_bulkUpdate`
- `spec/controllers/assignments_controller_spec.rb` — controller specs for the new action
- `features/assignments.feature` — scenario asserting the buttons render for instructors

## Test plan
- [x] CI green (RSpec + Cucumber)
- [x] Manual: as an instructor on a course page, click **Enable All Assignments** — confirm assignments with due dates flip to enabled and ones without due dates are skipped (reported in flash)
- [x] Manual: click **Disable All Assignments** — confirm every assignment flips to disabled
- [x] Manual: as a student, hit `/assignments/bulk_update_enabled` directly — confirm 403
